### PR TITLE
Bug/sign in error

### DIFF
--- a/lib/client/users/index.js
+++ b/lib/client/users/index.js
@@ -82,6 +82,7 @@ export const signInUserEmailPwd = async (email, pwd) => {
           break;
 
         default:
+          console.log(error);
           signInOutcome.error.email.hasError = true;
           signInOutcome.error.email.msg = "Something has gone wrong with the sign-in process. Please try again later.";
           break;

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@testing-library/jest-dom": "^5.11.9",
         "@testing-library/react": "^11.2.5",
         "babel-jest": "^26.6.3",
+        "env-cmd": "^10.1.0",
         "eslint-plugin-react-hooks": "^4.2.0",
         "jest": "^26.6.3"
       }
@@ -5074,6 +5075,31 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
       "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+    },
+    "node_modules/env-cmd": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
+      "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^4.0.0",
+        "cross-spawn": "^7.0.0"
+      },
+      "bin": {
+        "env-cmd": "bin/env-cmd.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/env-cmd/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/errno": {
       "version": "0.1.8",
@@ -18383,6 +18409,24 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
       "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+    },
+    "env-cmd": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
+      "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
+      "dev": true,
+      "requires": {
+        "commander": "^4.0.0",
+        "cross-spawn": "^7.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        }
+      }
     },
     "errno": {
       "version": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "main": "function.js",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "rm -rf .next/* && next build",
     "start": "next start",
-    "deploy": "npm run build && cross-env NODE_ENV=production firebase deploy",
+    "devLocal": "env-cmd -f ./.env.development npm run build && npm run start",
+    "devDeploy": "env-cmd -f ./.env.development npm run build && firebase deploy -P dev",
+    "prodDeploy": "npm run build && firebase deploy -P prod",
     "test": "jest --watch"
   },
   "dependencies": {
@@ -29,6 +31,7 @@
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "babel-jest": "^26.6.3",
+    "env-cmd": "^10.1.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "jest": "^26.6.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2442,6 +2442,11 @@
   "resolved" "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
   "version" "2.20.3"
 
+"commander@^4.0.0":
+  "integrity" "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+  "resolved" "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz"
+  "version" "4.1.1"
+
 "commondir@^1.0.1":
   "integrity" "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
   "resolved" "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
@@ -3139,6 +3144,14 @@
   "integrity" "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
   "resolved" "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz"
   "version" "2.1.0"
+
+"env-cmd@^10.1.0":
+  "integrity" "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA=="
+  "resolved" "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz"
+  "version" "10.1.0"
+  dependencies:
+    "commander" "^4.0.0"
+    "cross-spawn" "^7.0.0"
 
 "errno@^0.1.3", "errno@~0.1.7":
   "integrity" "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A=="


### PR DESCRIPTION
There was a bug which caused the deployed development environment to use the Firebase API key from the production environment, which was restricted to the production environment's domain. The issue here was that the initial NODE_ENV declared had no effect in Firebase, as the NODE_ENV could not be re-set (restricted environment variable).

After some tinkering, even when the environment was set to development, the issue was that NextJS attempted to overwrite files in the Firebase space, in development mode. This was incompatible for use as Firebase restricts files from being written / deleted in a Function.

The solution here was to utilise a package for us to force a specific environment file to be used in the build, via the env-cmd package. This allowed us to use the development environment variable file (.env.development) for the deployment of the dev environment, while keeping to the production environment variable file for the prod environment.